### PR TITLE
Fix/where are my responses

### DIFF
--- a/src/errorhandling/SpotifyError.ts
+++ b/src/errorhandling/SpotifyError.ts
@@ -1,0 +1,16 @@
+import type { ISpotifyError } from '../types.js';
+
+export default class SpotifyError extends Error implements ISpotifyError {
+    status: number;
+    statusText: string;
+    response: Response;
+    message: string;
+
+    constructor(status: number, statusText: string, message: string, response: Response) {
+        super(`API failed with status ${status}: ${statusText}`);
+        this.status = status;
+        this.statusText = statusText;
+        this.message = message;
+        this.response = response;
+    }
+}

--- a/src/responsevalidation/DefaultResponseValidator.ts
+++ b/src/responsevalidation/DefaultResponseValidator.ts
@@ -1,20 +1,41 @@
 import type { IValidateResponses } from "../types.js";
+import SpotifyError from "../errorhandling/SpotifyError.js";
 
 export default class DefaultResponseValidator implements IValidateResponses {
     public async validateResponse(response: Response): Promise<void> {
 
         switch (response.status) {
             case 401:
-                throw new Error("Bad or expired token. This can happen if the user revoked a token or the access token has expired. You should re-authenticate the user.");
+                throw new SpotifyError(
+                    response.status,
+                    response.statusText,
+                    "Bad or expired token. This can happen if the user revoked a token or the access token has expired. You should re-authenticate the user.",
+                    response
+                );
             case 403:
                 const body = await response.text();
-                throw new Error(`Bad OAuth request (wrong consumer key, bad nonce, expired timestamp...). Unfortunately, re-authenticating the user won't help here. Body: ${body}`);
+                throw new SpotifyError(
+                    response.status,
+                    response.statusText,
+                    `Bad OAuth request (wrong consumer key, bad nonce, expired timestamp...). Unfortunately, re-authenticating the user won't help here. Body: ${body}`,
+                    response
+                );
             case 429:
-                throw new Error("The app has exceeded its rate limits.");
+                throw new SpotifyError(
+                    response.status,
+                    response.statusText,
+                    "The app has exceeded its rate limits.",
+                    response
+                );
             default:
                 if (!response.status.toString().startsWith('20')) {
                     const body = await response.text();
-                    throw new Error(`Unrecognised response code: ${response.status} - ${response.statusText}. Body: ${body}`);
+                    throw new SpotifyError(
+                        response.status,
+                        response.statusText,
+                        `Unrecognised response code: ${response.status} - ${response.statusText}. Body: ${body}`,
+                        response
+                    );
                 }
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export interface IHandleErrors {
     handleErrors(error: any): Promise<boolean>;
 }
 
+export interface ISpotifyError {
+    status: number;
+    statusText: string;
+    message: string;
+    response: Response;  
+}
+
 export interface IValidateResponses {
     validateResponse: (response: Response) => Promise<any | null>;
 }


### PR DESCRIPTION
Summary

This PR implements a error handling class to store more information about the error that took place. Primarily this allows for the error to return the full response object.

The reason for this was to get access to the retry time header returned when we receive a 429 rate limit error.
Changes

- Added new interface ISpotifyError
- Added new class SpotifyError extending Error and implementing ISpotifyError
- Modified DefaultResponseValidator to throw SpotifyError with additional context to the error including the response

Results

Errors returned by failed requests will now have status, statusText and the response object that failed. This change is backwards compatible because it extends Error. Which was being returned prior to this change. This only adds additional context.
